### PR TITLE
Send valid event message when callback is valid

### DIFF
--- a/app/responses/__init__.py
+++ b/app/responses/__init__.py
@@ -8,10 +8,11 @@ class SuccessType(str, Enum):
 
 
 class FailureType(str, Enum):
-    RESOURCE_ERROR = 404
-    SYSTEM_ERROR = 500
     PARAMETER_ERROR = 400
+    UNAUTHORISED_ERROR = 401
+    RESOURCE_ERROR = 404
     VALIDATION_ERROR = 422
+    SYSTEM_ERROR = 500
 
 
 class ResponseFailure(BaseModel):
@@ -41,6 +42,12 @@ class ResponseFailure(BaseModel):
     def validation_error(cls, message=None):
         return cls(
             type=FailureType.VALIDATION_ERROR, message=cls._format_message(message)
+        )
+
+    @classmethod
+    def build_from_unauthorised_error(cls, message=None):
+        return cls(
+            type=FailureType.UNAUTHORISED_ERROR, message=cls._format_message(message)
         )
 
 

--- a/app/use_cases/create_new_callback.py
+++ b/app/use_cases/create_new_callback.py
@@ -37,7 +37,7 @@ class CreateNewCallback(BaseModel):
                 return enrolment_object_response
             # If request isn't failed, then an Enrolment object is returned, check shared_secret
             if enrolment_object_response.shared_secret != request.shared_secret:
-                return ResponseFailure.build_from_resource_error(
+                return ResponseFailure.build_from_unauthorised_error(
                     message="'shared_secret' key doesn't match"
                 )
 

--- a/tests/use_cases/test_create_new_callback.py
+++ b/tests/use_cases/test_create_new_callback.py
@@ -144,5 +144,5 @@ def test_create_new_callback_failure_on_invalid_shared_secret():
     response = use_case.execute(request)
 
     repo.save_callback.assert_not_called()
-    assert response.type == FailureType.RESOURCE_ERROR
+    assert response.type == FailureType.UNAUTHORISED_ERROR
     assert response.message == "'shared_secret' key doesn't match"


### PR DESCRIPTION
This PR solves [#79](https://github.com/monkeypants/transferrable_aged_care_microcredentials/issues/79).

It also corrects the error type for the invalid secret key because it has to return _401-UNAUTHORISED_.

Example response:

<img width="599" alt="image" src="https://user-images.githubusercontent.com/41292272/96255355-76b9f280-0fbf-11eb-8c1c-3179f6ece275.png">
