### PR TITLE
Ops: report deployment status to slack

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ orbs:
   codecov: codecov/codecov@1.0.2
   flake8: arrai/flake8@6.0.0
   aws-cli: circleci/aws-cli@1.3.0
+  slack: circleci/slack@4.0.2
 
 jobs:
   build-and-test:
@@ -54,6 +55,12 @@ jobs:
       - aws-cli/setup
       - run:
           command: make deploy_lambda STAGE=dev
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          event: pass
+          template: success_tagged_deploy_1
 
   deploy-to-prod:
     executor: aws-cli/default
@@ -62,6 +69,12 @@ jobs:
       - aws-cli/setup
       - run:
           command: make deploy_lambda STAGE=prod
+      - slack/notify:
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          event: pass
+          template: success_tagged_deploy_1
 workflows:
   main:
     jobs:
@@ -74,7 +87,13 @@ workflows:
           filters:
             branches:
               only: main
+          context:
+            - slack-secrets
       - deploy-to-prod:
           filters:
+            branches:
+              ignore: /.*/
             tags:
-              only: /v.*-stable/
+              only: /^v.*-stable/
+          context:
+            - slack-secrets


### PR DESCRIPTION
This PR adds slack notification on deployments. 

It's not possible to add slack notification for the whole build. We have to choose specific jobs, like code coverage, tests, etc.

That's why my opinion was to only focus on deployment on the main branch. if it failed, we all should know on slack. 


Q: why not do the same for each job?
A: because it would be a huge boilerplate in the file, and we would be sacrificing readability for a not-so-useful feature.

Also, keep in mind, that each developer gets an email when he has a failed job on his PR. there's no need for everyone to know these details until the PR is merged.

Q: What if I think there's another important thing to report?
A: Let me know, I will definitely add it. no questions asked!